### PR TITLE
If no features path, try using the behat configuration as a fallback

### DIFF
--- a/src/Behat/Symfony2Extension/Console/Processor/LocatorProcessor.php
+++ b/src/Behat/Symfony2Extension/Console/Processor/LocatorProcessor.php
@@ -100,6 +100,10 @@ class LocatorProcessor extends BaseProcessor
                 ->setBundleNamespace($bundle->getNamespace());
         }
 
+        if (!$featuresPath) {
+            $featuresPath = $this->container->getParameter('behat.paths.features');
+        }
+
         $this->container
             ->get('behat.console.command')
             ->setFeaturesPaths($featuresPath ? array($featuresPath) : array());


### PR DESCRIPTION
This works around the compat buster introduced by sha:8f38ead7bbc983575eabb1bf329652f506a8157a where running "behat" with no features specified would locate all .features below behat.paths.features.
