### PR TITLE
Made sure kernel is booted before and shut down after scenario outlines.

### DIFF
--- a/src/Behat/Symfony2Extension/Context/Initializer/KernelAwareInitializer.php
+++ b/src/Behat/Symfony2Extension/Context/Initializer/KernelAwareInitializer.php
@@ -63,7 +63,9 @@ class KernelAwareInitializer implements InitializerInterface, EventSubscriberInt
     {
         return array(
             'beforeScenario' => array('bootKernel', 1),
-            'afterScenario'  => array('shutdownKernel', -1)
+            'beforeOutlineExample' => array('bootKernel', 1),
+            'afterScenario'  => array('shutdownKernel', -1),
+            'afterOutlineExample'  => array('shutdownKernel', -1)
         );
     }
 


### PR DESCRIPTION
Kernel is not in a clean state between scenario outlines. 

Currently beforeScenario and afterScenario hooks are not run for scenario outlines. If it's not an intended behaviour I should probably rather create a PR for Behat.
