### PR TITLE
Doc fix: @ notation use

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -156,7 +156,7 @@ In order to start with your feature suite for specific bundle, execute:
 
 .. code-block:: bash
 
-    $ php behat.phar --init @YouBundleName
+    $ php behat.phar --init "@YouBundleName"
 
 .. note::
 
@@ -173,7 +173,7 @@ In order to run feature suite of specific bundle, execute:
 
 .. code-block:: bash
 
-    $ php behat.phar @YouBundleName
+    $ php behat.phar "@YouBundleName"
 
 .. note::
 
@@ -182,7 +182,7 @@ In order to run feature suite of specific bundle, execute:
 
     .. code-block:: bash
 
-        $ php behat.phar @YouBundleName/registration.feature
+        $ php behat.phar "@YouBundleName/registration.feature"
         $ php behat.phar src/YourCompany/YourBundleName/Features/registration.feature
 
 If you run specific bundle suite quite often, it might be useful to


### PR DESCRIPTION
The docs say to use bin/behat --init @YourBundle however this doesn't work as the @ sign isn't properly passed.  Using quotes fixes this and causes it to be generated in the correct spot.
