### PR TITLE
Register symfony2 session only if test environment

### DIFF
--- a/src/Behat/Symfony2Extension/Extension.php
+++ b/src/Behat/Symfony2Extension/Extension.php
@@ -45,27 +45,31 @@ class Extension implements ExtensionInterface
             $bundleName = preg_replace('/^\@/', '', $config['bundle']);
             $container->setParameter('behat.symfony2_extension.bundle', $bundleName);
         }
+
         if (isset($config['kernel'])) {
             foreach ($config['kernel'] as $key => $val) {
                 $container->setParameter('behat.symfony2_extension.kernel.'.$key, $val);
             }
         }
+
         if (isset($config['context'])) {
             foreach ($config['context'] as $key => $val) {
                 $container->setParameter('behat.symfony2_extension.context.'.$key, $val);
             }
         }
 
-        if ($config['mink_driver']) {
-            if (!class_exists('Behat\\Mink\\Driver\\BrowserKitDriver')) {
-                throw new \RuntimeException(
-                    'Install MinkBrowserKitDriver in order to activate symfony2 session.'
-                );
-            }
+        if (!isset($config['kernel'], $config['kernel']['env']) || 'test' === $config['kernel']['env']) {
+            if ($config['mink_driver']) {
+                if (!class_exists('Behat\\Mink\\Driver\\BrowserKitDriver')) {
+                    throw new \RuntimeException(
+                        'Install MinkBrowserKitDriver in order to activate symfony2 session.'
+                    );
+                }
 
-            $loader->load('mink_driver.xml');
-        } elseif (in_array('Behat\\MinkExtension\\Extension', $extensions) && class_exists('Behat\\Mink\\Driver\\BrowserKitDriver')) {
-            $loader->load('mink_driver.xml');
+                $loader->load('mink_driver.xml');
+            } elseif (in_array('Behat\\MinkExtension\\Extension', $extensions) && class_exists('Behat\\Mink\\Driver\\BrowserKitDriver')) {
+                $loader->load('mink_driver.xml');
+            }
         }
     }
 


### PR DESCRIPTION
Hi,

Although the extension allows you to switch at your own convenience in your behat configuration the environment for the kernel :

``` yaml
# ...
kernel;
  env: prod|test|dev|...
```

You can't really do it if you're already using `Mink` and `BrowserKitDriver` (or `GoutteDriver`, or any drivers that extends the BrowserDriver actually), or setting the `mink_loader` parameter to `true`. In some cases, you may need to have your app kernel, but not necessarly with the `KernelDriver` that is shipped with this extension (as it uses the `test.client`, which is not registered in Symfony2 unless you load the `test` parameter in the `FrameworkBundle` config).

That is why I think that the section registering the driver should be optionnal, if the kernel is not in a testing environment. Yes, I know that the environment name may change, or that I am not really controlling if the `default_session` of Mink is not `symfony2`, but that's all I found to prevent the driver from loading if not in test environment... If you have any suggestions to cover this, please feel free to tell.

Cheers.
