### PR TITLE
Add PHPUnit as a dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "behat/mink":                    "~1.4.3",
         "symfony/symfony":               "~2.1",
         "behat/mink-extension":          "~1.0.1",
-        "behat/mink-browserkit-driver":  "~1.0.4"
+        "behat/mink-browserkit-driver":  "~1.0.4",
+        "phpunit/phpunit":               "~3.7"
     },
 
     "autoload": {


### PR DESCRIPTION
Follows Behat in having PHPUnit as a dev requirement so it can be run without PEAR.

I'm expecting Travis to error due to existing problems, but this works locally.
