### PR TITLE
allowing strings for boolean options to better support BEHAT_PARAMS

### DIFF
--- a/src/Behat/Symfony2Extension/Extension.php
+++ b/src/Behat/Symfony2Extension/Extension.php
@@ -77,7 +77,9 @@ class Extension implements ExtensionInterface
     public function getConfig(ArrayNodeDefinition $builder)
     {
         $boolFilter = function ($v) {
-            return filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            $filtered = filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            return (null === $filtered) ? $v : $filtered;
         };
 
         $builder->


### PR DESCRIPTION
See #27

Implemented in terms of [FILTER_VALIDATE_BOOLEAN](http://php.net/manual/en/filter.filters.validate.php), so `"1"`, `"0"`, `"true"`, `"false"`, `"on"`, `"off"`, `"yes"` and `"no"` are now acceptable for the boolean options `kernel.debug` and `mink_driver`. Everything else will fail validation.
