### PR TITLE
Allow a base URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_script:
 script:
   - vendor/bin/behat -c=testapp/behat.yml -p=simple
   - vendor/bin/behat -c=testapp/behat.yml -p=web
+  - vendor/bin/behat -c=testapp/behat.yml -p=web_base_url

--- a/src/Behat/Symfony2Extension/Driver/KernelDriver.php
+++ b/src/Behat/Symfony2Extension/Driver/KernelDriver.php
@@ -22,8 +22,13 @@ use Behat\Mink\Driver\BrowserKitDriver;
  */
 class KernelDriver extends BrowserKitDriver
 {
-    public function __construct(KernelInterface $kernel)
+    public function __construct(KernelInterface $kernel, $baseUrl = null)
     {
-        parent::__construct($kernel->getContainer()->get('test.client'));
+        $client = $kernel->getContainer()->get('test.client');
+        if ($baseUrl !== null) {
+            $client->setServerParameter('SCRIPT_FILENAME', parse_url($baseUrl, PHP_URL_PATH));
+        }
+
+        parent::__construct($client);
     }
 }

--- a/src/Behat/Symfony2Extension/services/mink_driver.xml
+++ b/src/Behat/Symfony2Extension/services/mink_driver.xml
@@ -13,6 +13,7 @@
             <argument type="service">
                 <service class="%behat.symfony2_extension.driver.kernel.class%">
                     <argument type="service" id="behat.symfony2_extension.kernel" />
+                    <argument>%behat.mink.base_url%</argument>
                 </service>
             </argument>
             <argument type="service" id="behat.mink.selector.handler" />

--- a/testapp/behat.yml
+++ b/testapp/behat.yml
@@ -12,7 +12,7 @@ simple:
 
 web:
     filters:
-        tags: '@web'
+        tags: '@web&&~@base_url'
     context:
         class: 'Behat\Sf2DemoBundle\Features\Context\WebContext'
     extensions:
@@ -20,3 +20,15 @@ web:
             mink_driver: true
         Behat\MinkExtension\Extension:
             default_session: 'symfony2'
+
+web_base_url:
+    filters:
+        tags: '@web&&@base_url'
+    context:
+        class: 'Behat\Sf2DemoBundle\Features\Context\WebContext'
+    extensions:
+        Behat\Symfony2Extension\Extension:
+            mink_driver: true
+        Behat\MinkExtension\Extension:
+            default_session: 'symfony2'
+            base_url: http://localhost/foo/

--- a/testapp/src/Behat/Sf2DemoBundle/Features/web_base_url.feature
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/web_base_url.feature
@@ -1,0 +1,10 @@
+@web @base_url
+Feature: Web definitions
+  In order to combine the Symfony2 test driver with other drivers
+  As features tester
+  I need to be able to use a base URL
+
+  Scenario: Accessing default test controller
+    When I go to "/"
+    Then I should be on "http://localhost/foo/"
+    And I should see "Hello, stranger"


### PR DESCRIPTION
This is the alternative to https://github.com/Behat/MinkBrowserKitDriver/pull/25. As mentioned there, the `$_SERVER["SCRIPT_FILENAME"]` derivation might be better in this extension. If it is kept in the driver, though, this PR can be changed to just passing the base URL through.
