### PR TITLE
Added a proper Behat suite for the extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
 
 script:
   - vendor/bin/phpspec run -f pretty --no-interaction
-  - vendor/bin/behat -c=testapp/behat.yml
+  - vendor/bin/behat

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,0 +1,154 @@
+<?php
+
+use Behat\Behat\Context\TurnipAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * Behat context class.
+ */
+class FeatureContext implements TurnipAcceptingContext
+{
+    /**
+     * @var string
+     */
+    private $phpBin;
+    /**
+     * @var Process
+     */
+    private $process;
+
+    /**
+     * Prepares test folders in the temporary directory.
+     *
+     * @BeforeScenario
+     */
+    public function prepareProcess()
+    {
+        $phpFinder = new PhpExecutableFinder();
+        if (false === $php = $phpFinder->find()) {
+            throw new \RuntimeException('Unable to find the PHP executable.');
+        }
+        $this->phpBin = $php;
+        $this->process = new Process(null);
+    }
+
+    /**
+     * Runs behat command with provided parameters
+     *
+     * @When /^I run "behat(?: ((?:\"|[^"])*))?"$/
+     *
+     * @param   string $argumentsString
+     */
+    public function iRunBehat($argumentsString = '')
+    {
+        $argumentsString = strtr($argumentsString, array('\'' => '"'));
+
+        $this->process->setWorkingDirectory(__DIR__ . '/../../testapp');
+        $this->process->setCommandLine(
+            sprintf(
+                '%s %s %s %s',
+                $this->phpBin,
+                escapeshellarg(BEHAT_BIN_PATH),
+                $argumentsString,
+                strtr('--format-settings=\'{"timer": false}\'', array('\'' => '"', '"' => '\"'))
+            )
+        );
+        $this->process->start();
+        $this->process->wait();
+    }
+
+    /**
+     * Checks whether previously runned command passes|failes with provided output.
+     *
+     * @Then /^it should (fail|pass) with:$/
+     *
+     * @param   string       $success "fail" or "pass"
+     * @param   PyStringNode $text    PyString text instance
+     */
+    public function itShouldPassWith($success, PyStringNode $text)
+    {
+        $this->itShouldFail($success);
+        $this->theOutputShouldContain($text);
+    }
+
+    /**
+     * Checks whether last command output contains provided string.
+     *
+     * @Then the output should contain:
+     *
+     * @param   PyStringNode $text PyString text instance
+     */
+    public function theOutputShouldContain(PyStringNode $text)
+    {
+        PHPUnit_Framework_Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
+    }
+
+    private function getExpectedOutput(PyStringNode $expectedText)
+    {
+        $text = strtr($expectedText, array('\'\'\'' => '"""'));
+
+        // windows path fix
+        if ('/' !== DIRECTORY_SEPARATOR) {
+            $text = preg_replace_callback(
+                '/ features\/[^\n ]+/', function ($matches) {
+                    return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+                }, $text
+            );
+            $text = preg_replace_callback(
+                '/\<span class\="path"\>features\/[^\<]+/', function ($matches) {
+                    return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+                }, $text
+            );
+            $text = preg_replace_callback(
+                '/\+[fd] [^ ]+/', function ($matches) {
+                    return str_replace('/', DIRECTORY_SEPARATOR, $matches[0]);
+                }, $text
+            );
+        }
+
+        return $text;
+    }
+
+    /**
+     * Checks whether previously runned command failed|passed.
+     *
+     * @Then /^it should (fail|pass)$/
+     *
+     * @param   string $success "fail" or "pass"
+     */
+    public function itShouldFail($success)
+    {
+        if ('fail' === $success) {
+            if (0 === $this->getExitCode()) {
+                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+            }
+
+            PHPUnit_Framework_Assert::assertNotEquals(0, $this->getExitCode());
+        } else {
+            if (0 !== $this->getExitCode()) {
+                echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
+            }
+
+            PHPUnit_Framework_Assert::assertEquals(0, $this->getExitCode());
+        }
+    }
+
+    private function getExitCode()
+    {
+        return $this->process->getExitCode();
+    }
+
+    private function getOutput()
+    {
+        $output = $this->process->getErrorOutput() . $this->process->getOutput();
+
+        // Normalize the line endings in the output
+        if ("\n" !== PHP_EOL) {
+            $output = str_replace(PHP_EOL, "\n", $output);
+        }
+
+        return trim(preg_replace("/ +$/m", '', $output));
+    }
+}

--- a/features/bundle_suite.feature
+++ b/features/bundle_suite.feature
@@ -1,0 +1,18 @@
+Feature: Bundle suites
+  In order to define suites easily in a bundle
+  As a Symfony feature tester
+  I should be able to rely on some bundle conventions
+
+  Scenario: Features should be loaded from the bundle
+    When I run "behat -s simple --no-colors"
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  Scenario: Features should be loaded from all bundle suites
+    When I run "behat --no-colors"
+    Then it should pass with:
+      """
+      3 scenarios (3 passed)
+      """

--- a/features/locator.feature
+++ b/features/locator.feature
@@ -1,0 +1,18 @@
+Feature: Bundle locator
+  In order to filter the exercise easily
+  As a Symfony feature tester
+  I want to be able to use a bundle reference
+
+  Scenario: Features should be loaded from the bundle
+    When I run "behat --no-colors '@BehatSf2DemoBundle'"
+    Then it should pass with:
+      """
+      3 scenarios (3 passed)
+      """
+
+  Scenario: Specific features should be loaded from the bundle
+    When I run "behat --no-colors '@BehatSf2DemoBundle/web.feature'"
+    Then it should pass with:
+      """
+      2 scenarios (2 passed)
+      """


### PR DESCRIPTION
Instead of running the suite for the example app on Travis and expecting it to pass, which does not detect cases where the loading of features fails as with the Behat 3.0.0-RC2 tag, the extension has a proper suite which will run the testapp suite in different ways and assert the output.

Note that going from a successful build to a failed build is expected, because of the Behat bug https://github.com/Behat/Behat/pull/430 (this is actually how I detected the Behat bug, by doing the output assertion manually when looking at Travis)

Regarding the structure of the feature files, I'm not entirely satisfied with them, as they rely on the testapp and so they are not self-contained, but I don't know yet how to make them self-contained while keeping things readable. I will need to experiment a bit more with it.
