### PR TITLE
Pass the base URL to the driver

### DIFF
--- a/src/Behat/Symfony2Extension/Driver/KernelDriver.php
+++ b/src/Behat/Symfony2Extension/Driver/KernelDriver.php
@@ -22,8 +22,8 @@ use Behat\Mink\Driver\BrowserKitDriver;
  */
 class KernelDriver extends BrowserKitDriver
 {
-    public function __construct(KernelInterface $kernel)
+    public function __construct(KernelInterface $kernel, $baseUrl = null)
     {
-        parent::__construct($kernel->getContainer()->get('test.client'));
+        parent::__construct($kernel->getContainer()->get('test.client'), $baseUrl);
     }
 }

--- a/src/Behat/Symfony2Extension/services/mink_driver.xml
+++ b/src/Behat/Symfony2Extension/services/mink_driver.xml
@@ -13,6 +13,7 @@
             <argument type="service">
                 <service class="%behat.symfony2_extension.driver.kernel.class%">
                     <argument type="service" id="behat.symfony2_extension.kernel" />
+                    <argument>%behat.mink.base_url%</argument>
                 </service>
             </argument>
             <argument type="service" id="behat.mink.selector.handler" />


### PR DESCRIPTION
This follows on from #46. It makes use of https://github.com/Behat/MinkBrowserKitDriver/pull/25 by passing the Mink base URL to the driver.

(It's currently untested here as it would rely on a specific (unreleased) version of the BrowserKitDriver. When merged into the master branch it can be easily speced.)
