### PR TITLE
Handle container parameters and throw exceptions on missing services

### DIFF
--- a/spec/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolverSpec.php
+++ b/spec/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolverSpec.php
@@ -29,6 +29,48 @@ class ServiceArgumentResolverSpec extends ObjectBehavior
         );
     }
 
+    function it_resolves_parameters_inside_strings(
+        ReflectionClass $reflectionClass,
+        ContainerInterface $container
+    ) {
+        $container->getParameter('parameter')->willReturn('param_value');
+
+        $this->resolveArguments($reflectionClass, array('parameter' => 'my_%parameter%_is_here'))->shouldReturn(
+            array('parameter' => 'my_param_value_is_here')
+        );
+    }
+
+    function it_can_handle_multiple_parameters(
+        ReflectionClass $reflectionClass,
+        ContainerInterface $container
+    ) {
+        $container->getParameter('parameter1')->willReturn('param_value_1');
+        $container->getParameter('parameter2')->willReturn('param_value_2');
+
+        $this->resolveArguments($reflectionClass, array('parameter' => 'first_%parameter1%_then_%parameter2%'))->shouldReturn(
+            array('parameter' => 'first_param_value_1_then_param_value_2')
+        );
+    }
+
+    function it_unescapes_string_arguments_with_escaped_percentages(ReflectionClass $reflectionClass)
+    {
+        $this->resolveArguments($reflectionClass, array('parameter' => 'percent%%percent'))->shouldReturn(
+            array('parameter' => 'percent%percent')
+        );
+    }
+
+    function it_does_not_match_arguments_that_are_escaped(
+        ReflectionClass $reflectionClass,
+        ContainerInterface $container
+    ) {
+        $container->getParameter('parameter')->willReturn('param_value');
+
+        $this->resolveArguments($reflectionClass, array('parameter' => '%%parameter%%'))->shouldReturn(
+            array('parameter' => '%parameter%')
+        );
+    }
+
+
     function it_resolves_arguments_starting_with_at_sign_if_they_point_to_existing_service(
         ReflectionClass $reflectionClass,
         ContainerInterface $container
@@ -74,13 +116,6 @@ class ServiceArgumentResolverSpec extends ObjectBehavior
     {
         $this->resolveArguments($reflectionClass, array('service' => 'service@@'))->shouldReturn(
             array('service' => 'service@@')
-        );
-    }
-
-    function it_unescapes_string_arguments_with_escaped_percentages(ReflectionClass $reflectionClass)
-    {
-        $this->resolveArguments($reflectionClass, array('parameter' => 'percent%%percent'))->shouldReturn(
-            array('parameter' => 'percent%percent')
         );
     }
 }

--- a/src/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolver.php
+++ b/src/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolver.php
@@ -66,11 +66,9 @@ final class ServiceArgumentResolver implements ArgumentResolver
             return $service;
         }
 
-        if ($parameter = $this->getParameter($container, $argument)) {
-            return $parameter;
-        }
+        $withParameters = $this->replaceParameters($container, $argument);
 
-        return $this->escape($argument);
+        return $this->escape($withParameters);
     }
 
     /**
@@ -104,29 +102,13 @@ final class ServiceArgumentResolver implements ArgumentResolver
     /**
      * @param ContainerInterface $container
      * @param string $argument
-     * @return string|null
-     * @throws ParameterNotFoundException
+     * @return string
      */
-    private function getParameter(ContainerInterface $container, $argument)
+    private function replaceParameters(ContainerInterface $container, $argument)
     {
-        if ($argumentName = $this->getParameterName($argument)) {
-            return $container->getParameter($argumentName);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param string $argument
-     * @return string|null
-     */
-    private function getParameterName($argument)
-    {
-        if (preg_match('/^%(.*)%$/', $argument, $matches)) {
-            return $matches[1];
-        }
-
-        return null;
+        return preg_replace_callback('/(?<!%)%([^%]+)%(?!%)/', function($matches) use ($container) {
+            return $container->getParameter($matches[1]);
+        }, $argument);
     }
 
     /**


### PR DESCRIPTION
No longer passes through @service that does not match registered service - throws Exception instead.

Handles %parameters% as long as they are defined.

Respects service/parameter escaping rules
