### PR TITLE
Fix details of context config defaults in index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -256,6 +256,6 @@ configure Symfony2 kernel inside Behat to fulfil all your needs.
 * ``context`` - specifies options, used to guess the context class:
 
   - ``path_suffix`` - suffix from bundle directory for features. Defaults to
-    ``Features\Context\FeatureContext``.
-  - ``class_suffix`` - suffix from bundle classname for context class. Defaults to
     ``Features``.
+  - ``class_suffix`` - suffix from bundle classname for context class. Defaults to
+    ``Features\Context\FeatureContext``.


### PR DESCRIPTION
The defaults for path_suffix and class_suffix were mixed-up.