### PR TITLE
Bug report: Conflict in kernel lifecycle for Symfony test.client and Symfony2Extension 

### DIFF
--- a/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
@@ -10,9 +10,11 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class WebContext extends MinkContext implements KernelAwareContext
 {
     private $kernel;
+    private $session;
 
     public function __construct(Session $session, $simpleArg)
     {
+        $this->session = $session;
     }
 
     /**
@@ -24,5 +26,15 @@ class WebContext extends MinkContext implements KernelAwareContext
     public function setKernel(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
+    }
+
+
+    /**
+     * @Given /^I start with a correct session object$/
+     * @Then /^I should have the same instance of session$/
+     */
+    public function iShouldHaveTheSameInstanceOfSession()
+    {
+        \PHPUnit_Framework_Assert::assertSame($this->session, $this->kernel->getContainer()->get('session'));
     }
 }

--- a/testapp/src/Behat/Sf2DemoBundle/Features/context_service_injection_bug.feature
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/context_service_injection_bug.feature
@@ -1,0 +1,13 @@
+@web
+Feature: Context service injection bug
+  Once a request has been made with $contianer->get('test.client')->request()
+  the Kernel is shutdown, and subsequent requests have to re-initialize the
+  container & bundles.
+  This means that services injected into the constructor of a Context file are
+  not the same as those found in $contianer->get('test.client')->getContainer()
+
+  Scenario: Container services injected into Context classes should be equal to those in the test.client
+    Given I start with a correct session object
+    When I am on "/"
+    And I follow "Orc"
+    Then I should have the same instance of session

--- a/testapp/src/Behat/Sf2DemoBundle/Features/web.feature
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/web.feature
@@ -12,3 +12,9 @@ Feature: Web definitions
     Given I am on "/"
     When I follow "Orc"
     Then I should see "Hello, orc"
+
+  Scenario: Container services injected into Context classes should be the same as the application for the whole scenario
+    Given I start with a correct session object
+    When I am on "/"
+    And I follow "Orc"
+    Then I should have the same instance of session


### PR DESCRIPTION
When using this extension with the Mink integration, or using the `test.client` directly both this extension and the `test.client` try to manage the `boot` and/or `shutdown` of the kernel.

See:
* https://github.com/Behat/Symfony2Extension/blob/8263a4760c02ab6b6e29751c5fb8a28f44796d52/src/Behat/Symfony2Extension/Context/Initializer/KernelAwareInitializer.php#L45-L51
* https://github.com/symfony/FrameworkBundle/blob/3d6dd295fe3f323d93157ea9e9103cecfd78be19/Client.php#L99


This has two consequences.

1. Steps making a request cause the kernel to boot/shutdown (potential performance issue?)
2. Strange behaviour when injecting services into contexts. After a request is made, the service injected into the constructor is no longer the service that is being used by the `kernel` (because the container has been re-initialized.)

I am not sure if this is an issue, or something that can be realistically fixed. I experimented with preventing `test.client` from calling `KernelInterface::shutdown` however I ran into issues with sessions trying to re-initialize.