### PR TITLE
Remove Behat requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
 
     "require": {
         "php":                       ">=5.3.3",
-        "behat/behat":               "~3.0,>=3.0.4",
         "symfony/framework-bundle":  "~2.0"
     },
 
     "require-dev": {
         "symfony/symfony":               "~2.1",
+        "behat/behat":                   "~3.0,>=3.0.4",
         "behat/mink-extension":          "~2.0",
         "behat/mink-browserkit-driver":  "~1.0",
         "phpspec/phpspec":               "~2.0",


### PR DESCRIPTION
Because actually, Behat is installed on each project requiring this extension.

With a global install of Behat, this is not needed and add dependencies for nothing.