### PR TITLE
Added --dev to composer require statements

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,7 +23,7 @@ The recommended installation method is through `Composer <http://getcomposer.org
 
 .. code-block:: bash
 
-    $ composer require behat/symfony2-extension
+    $ composer require --dev behat/symfony2-extension
 
 You can then activate the extension in your ``behat.yml``:
 
@@ -156,7 +156,7 @@ BrowserKit driver for Mink:
 
 .. code-block:: bash
 
-    $ composer require behat/mink-extension behat/mink-browserkit-driver
+    $ composer require --dev behat/mink-extension behat/mink-browserkit-driver
 
 The new Mink driver will be available for usage:
 


### PR DESCRIPTION
To make sure it is installed only as dev dependency. Just like in the cookbook article: https://github.com/Behat/docs/blob/v3.0/cookbooks/1.symfony2_integration.rst