### PR TITLE
Add parameters injection example in tests

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -113,6 +113,27 @@ The FeatureContext will then be initialized with the Symfony2 session from the c
       }
   }
 
+Injecting Parameters
+--------------------
+
+You can also inject parameters of your Symfony application into a context if you escape
+the parameter name.
+
+The following example will inject the :code:`kernel.environment` parameter into the :code:`simpleArg`
+argument of the :code:`FeatureContext` context.
+
+.. code-block:: yaml
+
+  default:
+    suites:
+      default:
+          contexts:
+              - FeatureContext:
+                  simpleArg: '%%kernel.environment%%'
+                  session:   '@session'
+      extensions:
+        Behat\Symfony2Extension: ~
+
 
 Initialize Bundle Suite
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/testapp/behat.yml
+++ b/testapp/behat.yml
@@ -19,6 +19,7 @@ default:
             type: symfony_bundle
             contexts:
                 - Behat\Sf2DemoBundle\Features\Context\WebContext:
+                    simpleParameter: "%%custom_app%%"
                     simpleArg: 'string'
                     session:   '@session'
             bundle: 'BehatSf2DemoBundle'

--- a/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
@@ -11,7 +11,7 @@ class WebContext extends MinkContext implements KernelAwareContext
 {
     private $kernel;
 
-    public function __construct(Session $session, $simpleArg)
+    public function __construct(Session $session, $simpleParameter, $simpleArg)
     {
     }
 


### PR DESCRIPTION
Following #91, this PR adds an example of Symfony parameter injection.

The parameters needs to be quoted (double `%`) because the Behat configuration is also using Symfony's DIC and supports Behat's parameters injection such as `%paths.base%` for instance.