### PR TITLE
allow arrays as arguments in ServiceArgumentResolver

### DIFF
--- a/spec/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolverSpec.php
+++ b/spec/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolverSpec.php
@@ -125,4 +125,16 @@ class ServiceArgumentResolverSpec extends ObjectBehavior
             array('array' => array(1,2,3))
         );
     }
+
+    function it_resolves_arrays_of_strings_starting_with_at_sign(
+        ReflectionClass $reflectionClass,
+        ContainerInterface $container
+    ) {
+        $container->get('service1')->willReturn($service1 = new stdClass());
+        $container->get('service2')->willReturn($service2 = new stdClass());
+
+        $this->resolveArguments($reflectionClass, array('array' => array('@service1', '@service2')))->shouldReturn(
+            array('array' => array($service1, $service2))
+        );
+    }
 }

--- a/src/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolver.php
+++ b/src/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolver.php
@@ -60,6 +60,10 @@ final class ServiceArgumentResolver implements ArgumentResolver
      */
     private function resolveArgument($argument)
     {
+        if (is_array($argument)) {
+            return array_map(array($this, 'resolveArgument'), $argument);
+        }
+
         if (!is_string($argument)) {
             return $argument;
         }

--- a/testapp/behat.yml
+++ b/testapp/behat.yml
@@ -22,6 +22,14 @@ default:
                     simpleParameter: "%%custom_app%%"
                     simpleArg: 'string'
                     session:   '@session'
+                    services:
+                      - '@session'
+                      - '@session.storage.filesystem'
+                    params:
+                      - "%%kernel.root_dir%%"
+                      - "%%kernel.environment%%"
+                      - "%%kernel.debug%%"
+                      - "%%kernel.name%%"
             bundle: 'BehatSf2DemoBundle'
             filters:
                 tags: '@web'

--- a/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
@@ -11,7 +11,7 @@ class WebContext extends MinkContext implements KernelAwareContext
 {
     private $kernel;
 
-    public function __construct(Session $session, $simpleParameter, $simpleArg)
+    public function __construct(Session $session, $simpleParameter, $simpleArg, array $services, array $params)
     {
     }
 


### PR DESCRIPTION
Hi,

I have the need for arrays of service definitions, given as arguments for `FeatureContext::__construct` via behat.yml:

```yml
default:
    suites:
        default:
            contexts:
                - FeatureContext:
                    services: ['@service1', '@service2']
        extensions:
            Behat\Symfony2Extension: ~
```

This is not possible in the current version of Symfony2Extension. Therefore I changed the `ServiceArgumentResolver::resolveArgument` a bit. Is this change ok for you?

Regards,
Sascha