### PR TITLE
Resolve issue where Symfony2 collection parameters fail to be injected

### DIFF
--- a/features/bundle_suite.feature
+++ b/features/bundle_suite.feature
@@ -7,12 +7,12 @@ Feature: Bundle suites
     When I run "behat -s simple --no-colors"
     Then it should pass with:
       """
-      1 scenario (1 passed)
+      2 scenarios (2 passed)
       """
 
   Scenario: Features should be loaded from all bundle suites
     When I run "behat --no-colors"
     Then it should pass with:
       """
-      3 scenarios (3 passed)
+      4 scenarios (4 passed)
       """

--- a/features/locator.feature
+++ b/features/locator.feature
@@ -7,7 +7,7 @@ Feature: Bundle locator
     When I run "behat --no-colors '@BehatSf2DemoBundle'"
     Then it should pass with:
       """
-      3 scenarios (3 passed)
+      4 scenarios (4 passed)
       """
 
   Scenario: Specific features should be loaded from the bundle

--- a/spec/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolverSpec.php
+++ b/spec/Behat/Symfony2Extension/Context/Argument/ServiceArgumentResolverSpec.php
@@ -23,9 +23,22 @@ class ServiceArgumentResolverSpec extends ObjectBehavior
         ContainerInterface $container
     ) {
         $container->getParameter('parameter')->willReturn('param_value');
+        $container->hasParameter('parameter')->willReturn(true);
 
         $this->resolveArguments($reflectionClass, array('parameter' => '%parameter%'))->shouldReturn(
             array('parameter' => 'param_value')
+        );
+    }
+
+    function it_resolves_parameters_starting_and_ending_with_percentage_sign_if_they_point_to_parameter_collection(
+        ReflectionClass $reflectionClass,
+        ContainerInterface $container
+    ) {
+        $container->getParameter('parameter')->willReturn(array('Param 1', 'Param 2'));
+        $container->hasParameter('parameter')->willReturn(true);
+
+        $this->resolveArguments($reflectionClass, array('parameter' => '%parameter%'))->shouldReturn(
+            array('parameter' => array('Param 1', 'Param 2'))
         );
     }
 

--- a/testapp/app/config/config.yml
+++ b/testapp/app/config/config.yml
@@ -11,3 +11,6 @@ framework:
 
 parameters:
     custom_app: 'behat-test-app'
+    collection_param:
+        - 'Param 1'
+        - 'Param 2'

--- a/testapp/behat.yml
+++ b/testapp/behat.yml
@@ -30,6 +30,8 @@ default:
                       - "%%kernel.environment%%"
                       - "%%kernel.debug%%"
                       - "%%kernel.name%%"
+                    nestedParam: 'nested_parameter_%%custom_app%%'
+                    collectionParam: '%%collection_param%%'
             bundle: 'BehatSf2DemoBundle'
             filters:
                 tags: '@web'

--- a/testapp/src/Behat/Sf2DemoBundle/Features/Context/FeatureContext.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/Context/FeatureContext.php
@@ -62,4 +62,23 @@ class FeatureContext implements KernelAwareContext
     {
         \PHPUnit_Framework_Assert::assertSame($val, $this->containerParameters[$this->parameterKey]);
     }
+
+    /**
+     * @Then the value should be an array
+     */
+    public function theValueShouldBeAnArray()
+    {
+        \PHPUnit_Framework_Assert::assertInternalType('array', $this->containerParameters[$this->parameterKey]);
+    }
+
+    /**
+     * @Then the array should contain only the values :arg
+     * @param  string $arg Comma delimited string, to represent an array's values
+     */
+    public function theArrayShouldContainOnlyTheValues($arg)
+    {
+        $values = explode(',', $arg);
+        
+        \PHPUnit_Framework_Assert::assertSame($values, $this->containerParameters[$this->parameterKey]);
+    }
 }

--- a/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
@@ -11,7 +11,7 @@ class WebContext extends MinkContext implements KernelAwareContext
 {
     private $kernel;
 
-    public function __construct(Session $session, $simpleParameter, $simpleArg, array $services, array $params)
+    public function __construct(Session $session, $simpleParameter, $simpleArg, array $services, array $params, $nestedParam, $collectionParam)
     {
     }
 

--- a/testapp/src/Behat/Sf2DemoBundle/Features/kernel_access.feature
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/kernel_access.feature
@@ -9,3 +9,10 @@ Feature: Kernel access
     Then there should be "custom_app" parameter
     And it should be set to "behat-test-app" value
     But there should not be "custom2" parameter
+
+  Scenario: Allow handling of container parameters which are collections
+    Given I have a kernel instance
+    When I get container parameters from it
+    Then there should be "collection_param" parameter
+    And the value should be an array
+    And the array should contain only the values "Param 1,Param 2"


### PR DESCRIPTION
This allows collection parameters defined in Symfony 2 to be injected. Fixes #117.

Currently, they fail to do so as there is a constraint that `preg_replace_callback` must return a string, but when resolving parameters from Symfony 2's container, you may either get back a `string`, `constant`, or `collection` (see [here](http://symfony.com/doc/2.8/service_container/parameters.html)).

I've swapped to using `preg_match` which will return a string, and I have changed the method signature of `replaceParameters` so that it returns the container value of the parameter. Then, if it is not a string, we return it to the caller (to avoid another issue passing it to `@escape`), otherwise the `escape` method is still called on it, and then returned.