### PR TITLE
Remove HHVM from Travis CI Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
       env: SYMFONY_VERSION='2.8.*'
     - php: 7.0
       env: DEPS=dev SYMFONY_VERSION='3.0.*'
-    - php: hhvm
-      env: DEPS=dev SYMFONY_VERSION='3.0.*'
   allow_failures:
     - php: 7.0
       env: SYMFONY_VERSION='3.0.*'


### PR DESCRIPTION
This PR removes the HHVM build from Travis CI's build matrix; as mentioned in #119 it is no longer supported by both Travis, and Symfony 4. Removing it as it's blocking #119.