### PR TITLE
A Configuration Option for being able to retain container between requests

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -34,6 +34,21 @@ class FeatureContext implements SnippetAcceptingContext
         $this->process = new Process(null);
     }
 
+
+    /**
+     * @Given I have not configured behat to use shared kernel
+     */
+    public function iHaveNotConfiguredBehatToUseSharedKernel()
+    {
+    }
+
+    /**
+     * @Given I have configured behat to use shared kernel
+     */
+    public function iHaveConfiguredBehatToUseSharedKernel()
+    {
+    }
+
     /**
      * Runs behat command with provided parameters
      *

--- a/features/shared_kernel.feature
+++ b/features/shared_kernel.feature
@@ -1,0 +1,22 @@
+Feature: Sharing Behat's kernel with the application if config stipulates
+
+    In order to be able to re-use in-memory services between scenario steps
+    As a Symfony feature tester
+    I need to be able to share Behat's DI container with the app
+
+    Scenario: Fails to retain service when shared kernel set to false
+        Given I have not configured behat to use shared kernel
+        When I run "behat -s web -p no-shared-kernel --no-colors '@BehatSf2DemoBundle/services.feature'"
+        Then it should fail
+        And the output should contain:
+          """
+          -'Jim'
+          """
+
+    Scenario: Does retain service when shared kernel set to true
+        Given I have configured behat to use shared kernel
+        When I run "behat -s web -p shared-kernel --no-colors '@BehatSf2DemoBundle/services.feature'"
+        Then it should pass with:
+          """
+          1 scenario (1 passed)
+          """

--- a/src/Behat/Symfony2Extension/Driver/KernelDriver.php
+++ b/src/Behat/Symfony2Extension/Driver/KernelDriver.php
@@ -12,6 +12,7 @@
 namespace Behat\Symfony2Extension\Driver;
 
 use Behat\Mink\Driver\BrowserKitDriver;
+use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -21,8 +22,12 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class KernelDriver extends BrowserKitDriver
 {
-    public function __construct(KernelInterface $kernel, $baseUrl = null)
+    public function __construct(KernelInterface $kernel, $baseUrl = null, $shared = false)
     {
-        parent::__construct($kernel->getContainer()->get('test.client'), $baseUrl);
+        $client = (true === $shared) ?
+            new Client($kernel) :
+            $kernel->getContainer()->get('test.client');
+
+        parent::__construct($client, $baseUrl);
     }
 }

--- a/src/Behat/Symfony2Extension/ServiceContainer/Driver/SymfonyFactory.php
+++ b/src/Behat/Symfony2Extension/ServiceContainer/Driver/SymfonyFactory.php
@@ -59,6 +59,7 @@ final class SymfonyFactory implements DriverFactory
         return new Definition('Behat\Symfony2Extension\Driver\KernelDriver', array(
             new Reference(Symfony2Extension::KERNEL_ID),
             '%mink.base_url%',
+            '%symfony2_extension.kernel.shared%'
         ));
     }
 }

--- a/src/Behat/Symfony2Extension/ServiceContainer/Symfony2Extension.php
+++ b/src/Behat/Symfony2Extension/ServiceContainer/Symfony2Extension.php
@@ -80,6 +80,12 @@ class Symfony2Extension implements ExtensionInterface
                             ->end()
                             ->defaultTrue()
                         ->end()
+                        ->booleanNode('shared')
+                            ->beforeNormalization()
+                                ->ifString()->then($boolFilter)
+                            ->end()
+                            ->defaultFalse()
+                        ->end()
                     ->end()
                 ->end()
                 ->arrayNode('context')
@@ -180,6 +186,7 @@ class Symfony2Extension implements ExtensionInterface
         $container->setDefinition(self::KERNEL_ID, $definition);
         $container->setParameter(self::KERNEL_ID . '.path', $config['path']);
         $container->setParameter(self::KERNEL_ID . '.bootstrap', $config['bootstrap']);
+        $container->setParameter(self::KERNEL_ID . '.shared', $config['shared']);
     }
 
     private function loadSuiteGenerator(ContainerBuilder $container, array $config)

--- a/testapp/app/config/config.yml
+++ b/testapp/app/config/config.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: services.yml }
+
 framework:
     secret:          test_blah
     router:

--- a/testapp/app/config/routing.yml
+++ b/testapp/app/config/routing.yml
@@ -1,3 +1,7 @@
 test:
     path:  /
     defaults: { _controller: BehatSf2DemoBundle:Test:index }
+
+test-service:
+    path:  /set-name/{name}
+    defaults: { _controller: BehatSf2DemoBundle:Test:setName }

--- a/testapp/app/config/services.yml
+++ b/testapp/app/config/services.yml
@@ -1,0 +1,3 @@
+services:
+    name.service:
+        class: Behat\Sf2DemoBundle\Service\NameService

--- a/testapp/behat.yml
+++ b/testapp/behat.yml
@@ -14,7 +14,7 @@ default:
             type: symfony_bundle
             bundle: 'BehatSf2DemoBundle'
             filters:
-                tags: '~@web'
+                tags: '~@web && ~@shared-kernel'
         web:
             type: symfony_bundle
             contexts:
@@ -30,6 +30,28 @@ default:
                       - "%%kernel.environment%%"
                       - "%%kernel.debug%%"
                       - "%%kernel.name%%"
+                    nameService: '@name.service'
+
             bundle: 'BehatSf2DemoBundle'
             filters:
-                tags: '@web'
+                tags: '@web && ~@shared-kernel'
+
+shared-kernel:
+    extensions:
+        Behat\Symfony2Extension:
+            kernel:
+                shared: true
+    suites:
+        web:
+            filters:
+                tags: '@shared-kernel'
+
+no-shared-kernel:
+    extensions:
+        Behat\Symfony2Extension:
+            kernel:
+                shared: false
+    suites:
+        web:
+            filters:
+                tags: '@shared-kernel'

--- a/testapp/src/Behat/Sf2DemoBundle/Controller/TestController.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Controller/TestController.php
@@ -26,4 +26,11 @@ class TestController extends Controller
 RESPONSE
         );
     }
+
+    public function setNameAction($name)
+    {
+        $this->container->get('name.service')->setName($name);
+
+        return new Response();
+    }
 }

--- a/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/Context/WebContext.php
@@ -3,16 +3,24 @@
 namespace Behat\Sf2DemoBundle\Features\Context;
 
 use Behat\MinkExtension\Context\MinkContext;
+use Behat\Sf2DemoBundle\Service\NameService;
 use Behat\Symfony2Extension\Context\KernelAwareContext;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class WebContext extends MinkContext implements KernelAwareContext
 {
     private $kernel;
+    
+    /**
+     * @var NameService
+     */
+    private $nameService;
 
-    public function __construct(Session $session, $simpleParameter, $simpleArg, array $services, array $params)
+    public function __construct(Session $session, $simpleParameter, $simpleArg, array $services, array $params, NameService $nameService)
     {
+        $this->nameService = $nameService;
     }
 
     /**
@@ -24,5 +32,30 @@ class WebContext extends MinkContext implements KernelAwareContext
     public function setKernel(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
+    }
+
+    /**
+     * @Given I have a service set to :name
+     */
+    public function iHaveANameService($name)
+    {
+        $this->nameService->setName($name);
+    }
+
+    /**
+     * @When make a request setting name to :name
+     */
+    public function makeARequestSettingNameTo($name)
+    {
+        $this->visit('set-name/'.$name);
+    }
+
+    /**
+     * @Then the service value should have remained :name
+     * @Then the service value should have changed to :name
+     */
+    public function theServiceValueShouldRemain($name)
+    {
+        Assert::assertEquals($name, $this->nameService->getName());
     }
 }

--- a/testapp/src/Behat/Sf2DemoBundle/Features/services.feature
+++ b/testapp/src/Behat/Sf2DemoBundle/Features/services.feature
@@ -1,0 +1,8 @@
+Feature: Retaining container between requests
+
+  @shared-kernel
+  Scenario: Service retains value between request and assertion for duration of scenario
+    Given I have a service set to "Jack"
+    And I am on "/"
+    When make a request setting name to "Jim"
+    Then the service value should have changed to "Jim"

--- a/testapp/src/Behat/Sf2DemoBundle/Service/NameService.php
+++ b/testapp/src/Behat/Sf2DemoBundle/Service/NameService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Behat\Sf2DemoBundle\Service;
+
+class NameService
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
In the simplest case where you make only one request to your app - access to the services in the container from Behat context file works, but once you make another request then Symfony will reboot the kernel and you will lose access to the container from the Behat context files.

If I am running a scenario where I set the value of a symfony service in the Given step (for example an in-memory repository), make a request to load a form and then make another request to press the form button (which will have an effect of setting a value in this service), I will no longer have access to the original instance of the service from Behat. 

Using this option, I construct the a new "test.client" (instead of the existing one) using an instance of *Behat's* kernel. Effectively, the kernel is only rebooted once every scenario rather than every request.

I find the possibility of this very useful when running scenarios against in-memory repositories, though I suppose it should be made clear that this option should it potentially dangerous as it changes the way symfony would normally work, and means that if you had stateful services then there is no guarantee what state they will be in after the first request. 