### PR TITLE
Symfony v4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,15 @@ matrix:
       env: DEPS=dev SYMFONY_VERSION='3.0.*'
     - php: 7.1
       env: DEPS=dev SYMFONY_VERSION='3.0.*'
+    - php: 7.1
+      env: DEPS=dev SYMFONY_VERSION='4.0.*'
   allow_failures:
     - php: 7.0
       env: SYMFONY_VERSION='3.0.*'
     - php: 7.1
       env: SYMFONY_VERSION='3.0.*'
+    - php: 7.1
+      env: SYMFONY_VERSION='4.0.*'
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "require": {
         "php":                       ">=5.3.3",
         "behat/behat":               "~3.0,>=3.0.4",
-        "symfony/framework-bundle":  "~2.0|~3.0"
+        "symfony/framework-bundle":  "~2.0|~3.0|~4.0"
     },
 
     "require-dev": {
-        "symfony/symfony":               "~2.1|~3.0",
+        "symfony/symfony":               "~2.1|~3.0|~4.0",
         "behat/mink-extension":          "~2.0",
         "behat/mink-browserkit-driver":  "~1.0",
         "phpspec/phpspec":               "~2.0",


### PR DESCRIPTION
Issue https://github.com/Behat/Symfony2Extension/issues/134 suggests to add support for Symfony v4

PR https://github.com/Behat/Symfony2Extension/pull/126 offers support for Symfony v4 DEV, however it has been already released

IMHO there is no need to remove previous Travis CI versions due this extension is still working on those ones