### PR TITLE
Prevent require dir error when kernel path is null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   include:
     - php: 5.5
       env: SYMFONY_VERSION='2.7.*'
+      dist: trusty
     - php: 5.6
       env: SYMFONY_VERSION='2.8.*'
     - php: 7.1

--- a/src/Behat/Symfony2Extension/ServiceContainer/Symfony2Extension.php
+++ b/src/Behat/Symfony2Extension/ServiceContainer/Symfony2Extension.php
@@ -135,10 +135,12 @@ class Symfony2Extension implements ExtensionInterface
 
         // find and require kernel
         $kernelPath = $container->getParameter('symfony2_extension.kernel.path');
-        if (file_exists($kernel = $basePath . '/' . $kernelPath)) {
-            $container->getDefinition(self::KERNEL_ID)->setFile($kernel);
-        } elseif (file_exists($kernelPath)) {
-            $container->getDefinition(self::KERNEL_ID)->setFile($kernelPath);
+        if ($kernelPath) {
+            if (file_exists($kernel = $basePath . '/' . $kernelPath)) {
+                $container->getDefinition(self::KERNEL_ID)->setFile($kernel);
+            } elseif (file_exists($kernelPath)) {
+                $container->getDefinition(self::KERNEL_ID)->setFile($kernelPath);
+            }
         }
     }
 


### PR DESCRIPTION
Bug fix: yes.

After #141, the new default value for kernel `bootstrap` and `path` options is `null`, but, unlike for `bootstrap`, the processing of `path` doesn't check for emptiness, thus the test `file_exists($kernel = $basePath . '/' . $kernelPath)` where `$kernelPath` is null (or empty string) does like `file_exists($kernel = $basePath . '/')` *which is true* although `$kernel` then denotes a **directory** (not a file) which later causes an error.

So I simply added a check similar to `$bootstrapPath` a few lines above.