### PR TITLE
Formally abandon the composer package, mention the BC fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Warning
 
-This library is archived and will not be maintained. The maintained alternative is [FriendsOfBehat/SymfonyExtension](https://github.com/FriendsOfBehat/SymfonyExtension).
+This library is archived and will not be maintained. The recommended maintained alternative is [FriendsOfBehat/SymfonyExtension](https://github.com/FriendsOfBehat/SymfonyExtension).
+
+There is also a fork at [https://github.com/PHPExpertsInc/SymfonyExtension/](https://github.com/PHPExpertsInc/SymfonyExtension/)
+which added support for PHP 8.x and Symfony <= 7. It claims to be entirely backwards compatible with this library 
+(meaning it shares the same architectural flaws that originally prompted the new extension). It is **not officially 
+recommended** by the Behat maintainers, but it may be useful as a temporary migration path for existing projects.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "behat/symfony2-extension",
+    "abandoned": "friends-of-behat/symfony-extension",
     "type": "behat-extension",
     "description": "Symfony2 framework extension for Behat",
     "keywords": ["symfony", "framework", "bdd"],


### PR DESCRIPTION
The README was updated in 2022 to mark the project as archived, but it was never formally abandoned on packagist.

I'm also aware that moving to FriendsOfBehat/SymfonyExtension involves a BC break. Although this is ultimately a good thing - there are good reasons why the architecture changed - I don't think it hurts to mention the backwards compatible fork that was submitted in #162, with a heavy caveat that it is not officially recommended.